### PR TITLE
[0.5pt] Find external API - group task#40

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .vscode/
+.env

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-eslint": "10.x",
     "babel-loader": "^8.2.5",
     "css-loader": "^6.7.1",
+    "dotenv-webpack": "^8.0.1",
     "eslint": "7.x",
     "eslint-config-airbnb-base": "14.x",
     "eslint-plugin-import": "2.x",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,13 @@
 import addFavicon from './modules/addFavicon';
+import getMedia from './modules/getMedia';
 import './styles/styles.css';
 
-window.onload = () => {
+const baseUrl = process.env.BASE_URL;
+const apiKey = process.env.API_KEY;
+const url = `${baseUrl}/trending/all/day?api_key=${apiKey}`;
+
+window.onload = async () => {
   addFavicon();
+  const mediaList = await getMedia(url);
+  console.log(mediaList);
 };

--- a/src/modules/getMedia.js
+++ b/src/modules/getMedia.js
@@ -1,0 +1,6 @@
+const getMedia = (url) => fetch(url)
+  .then((response) => response.json())
+  .then((response) => response.results)
+  .catch((error) => console.log(error));
+
+export default getMedia;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const DotEnv = require('dotenv-webpack');
 
 module.exports = {
   mode: 'production',
@@ -57,6 +58,7 @@ module.exports = {
       filename: 'index.html',
       template: 'src/index.html',
     }),
+    new DotEnv(),
   ],
   optimization: {
     minimizer: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4296,6 +4296,25 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv-defaults@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz#6b3ec2e4319aafb70940abda72d3856770ee77ac"
+  integrity sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==
+  dependencies:
+    dotenv "^8.2.0"
+
+dotenv-webpack@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz#6656550460a8076fab20e5ac2eac867e72478645"
+  integrity sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==
+  dependencies:
+    dotenv-defaults "^2.0.2"
+
+dotenv@^8.2.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
+
 duplexer3@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.5.tgz#0b5e4d7bad5de8901ea4440624c8e1d20099217e"


### PR DESCRIPTION
## Find External API

- Successfully mapped app to TV Shows data. I opted to use themoviedb.org as the source API instead of TVMaze, because their API is better organized and structured
- I've made changes to the webpack config to add dotEnv

[Task Link](https://github.com/WalterOkumu/tv-show/issues/40)